### PR TITLE
Changing sign of wrist y-position in Kinematic Chains docs

### DIFF
--- a/src/geometry_kinematic_chains.md
+++ b/src/geometry_kinematic_chains.md
@@ -98,7 +98,7 @@ Using Kinetics Toolkit, we can solve this example by performing the last equatio
 import kineticstoolkit.lab as ktk
 
 # position of the wrist in the forearm coordinate system
-forearm_p_wrist = [[0, 0.34, 0, 1]]
+forearm_p_wrist = [[0, -0.34, 0, 1]]
 
 # forearm frame in the upper arm coordinate system
 upperarm_T_forearm = ktk.geometry.create_transforms(


### PR DESCRIPTION
Hello! Thank you for your work on the kineticstoolkit and this fantastic repo of documentation. It's been an incredibly helpful resource to me!

I was working through the examples in [9.4 Kinematic Chains](https://kineticstoolkit.uqam.ca/doc/geometry_kinematic_chains.html) and came across one minor part of the documentation that I believe needs updating (and if not, I'd love to better understand). Specifically, the y-position of the wrist in the forearm coordinate system is currently set to `0.34`. Using that position, when I calculate the global positions of the shoulder, elbow, and wrist (following the examples in [9.3.3](https://kineticstoolkit.uqam.ca/doc/geometry_transform_changing_coordinate_system_example.html)), and plot them, they look like this.

![t1](https://github.com/kineticstoolkit/kineticstoolkit_doc/assets/32135129/c3f1e998-57c3-4e3f-834e-e23b844d560d)

Since [Fig 9.4](https://kineticstoolkit.uqam.ca/doc/geometry_local_coordinates.html#fig-geometry-local-coordinates-rotated) defines the y-axis in the vertical direction, I believe that the y-position of the wrist, relative to the forearm, should be `-0.34`. When I make that update and re-plot the global joint positions, the shape of the arm matches the form of Fig 9.4.

![t2](https://github.com/kineticstoolkit/kineticstoolkit_doc/assets/32135129/dde31fae-b057-404f-b834-8b5c0fde5276)

For reference, this is the plotting script that I used.

```python
import matplotlib.pyplot as plt
import numpy as np

global_p_forearm = global_T_forearm[:, :, 3]
global_p_upperarm = global_T_upperarm[:, :, 3]

# arm segments
x = np.array([global_p_upperarm[0, 0], global_p_forearm[0, 0], global_p_wrist[0, 0]])
y = np.array([global_p_upperarm[0, 1], global_p_forearm[0, 1], global_p_wrist[0, 1]])

plt.plot(x, y, c="grey")
plt.scatter(global_p_upperarm[:, 0], global_p_upperarm[:, 1], label="upperarm")
plt.scatter(global_p_forearm[:, 0], global_p_forearm[:, 1], label="forearm")
plt.scatter(global_p_wrist[:, 0], global_p_wrist[:, 1], label="wrist")

plt.legend()
plt.xlim(0, .8)
plt.ylim(0, .8);
```

Thank you!